### PR TITLE
Remove click dependency from textx-ls-core

### DIFF
--- a/textX-LS/core/setup.py
+++ b/textX-LS/core/setup.py
@@ -50,7 +50,7 @@ setup(
     packages=packages,
     include_package_data=True,
     package_data={"": ["*.tx"]},
-    install_requires=["textX>=2.1.0", "click==7.0", "wheel_inspect==1.3.0"],
+    install_requires=["textX>=2.1.0", "wheel_inspect==1.3.0"],
     extras_require={
         "dev": dev_require,
         "test": tests_require,


### PR DESCRIPTION
_click_ dependency is not needed until we start working on a CLI.

Closes #38.