### PR TITLE
fix: Support python older than 3.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 25.11.0
     hooks:
     - id: black
       language_version: python3.12
@@ -9,7 +9,7 @@ repos:
     hooks:
     - id: flake8
 -   repo: https://github.com/PyCQA/bandit
-    rev: '1.6.2'
+    rev: '1.9.1'
     hooks:
     -   id: bandit
         args: [--recursive, -x, tests, -c, .bandit]

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog],
 and this project adheres to [Semantic Versioning][semver].
 
-## [unreleased]
+## [0.3.1]
+
+### Fixed
+- Support Python older than 3.11
 
 ## [0.3.0] (released 2025-05-09)
 

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "displayName": "textX",
   "description": "VS Code extension for domain specific languages based on textX",
   "license": "MIT",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "textX",
   "icon": "media/textX-logo.png",
   "author": {

--- a/textX-LS/core/CHANGELOG.md
+++ b/textX-LS/core/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][keepachangelog],
 and this project adheres to [Semantic Versioning][semver].
 
-## [unreleased]
+## [0.3.1]
+
+### Fixed
+- Support Python older than 3.11
 
 ## [0.3.0] (released 2025-05-09)
 

--- a/textX-LS/core/pyproject.toml
+++ b/textX-LS/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "textx-ls-core"
-version = "0.3.0"
+version = "0.3.1"
 description = "a core language server logic for domain specific languages based on textX"
 authors = [
     {name = "Daniel Elero", email = "danixeee@gmail.com"},
@@ -34,6 +34,7 @@ classifiers = [
 dependencies = [
     "textX>=4.2.0",
     "wheel_inspect==1.7.1",
+    "tomli>=2.3.0; python_version < \"3.11\"",
 ]
 
 [project.urls]

--- a/textX-LS/core/textx_ls_core/utils.py
+++ b/textX-LS/core/textx_ls_core/utils.py
@@ -99,7 +99,10 @@ def get_project_name_and_version(
     # ... or pyproject.toml
     pyproject = join(folder_or_wheel, "pyproject.toml")
     if isfile(pyproject):
-        import tomllib  # Requires Python 3.11+ standard library
+        try:
+            import tomllib  # Python 3.11+
+        except ModuleNotFoundError:
+            import tomli as tomllib  # Python < 3.11
 
         with open(pyproject, "rb") as f:
             data = tomllib.load(f)

--- a/textX-LS/server/textx_ls_server/config.py
+++ b/textX-LS/server/textx_ls_server/config.py
@@ -1,2 +1,2 @@
 PACKAGE_NAME = "textx-ls-server"
-VERSION = "0.2.0"
+VERSION = "0.3.0"

--- a/textX-LS/server/textx_ls_server/protocol.py
+++ b/textX-LS/server/textx_ls_server/protocol.py
@@ -118,7 +118,9 @@ class TextXProtocol(LanguageServerProtocol):
     """
 
     @lsp_method(TEXT_DOCUMENT_DID_CHANGE)
-    def lsp_text_document__did_change(self, params: DidChangeTextDocumentParams) -> None:
+    def lsp_text_document__did_change(
+        self, params: DidChangeTextDocumentParams
+    ) -> None:
         """Updates document's content if document is in the workspace.
 
         Args:
@@ -174,7 +176,7 @@ class TextXProtocol(LanguageServerProtocol):
                     )
                 )
                 return
-            
+
             self.workspace._text_documents[doc_uri] = TextXDocument(
                 doc_uri,
                 self._get_project_root(doc_uri),


### PR DESCRIPTION
- textX core changes:
  - added fallback to `tomli` when importing from `tomllib`
  - added `tomli` lib dependency to textX core in case of python<3.11
  - set version to 0.3.1
- set vscode extension version to 0.3.1
- fix `VERSION` in `config.py` (server project)
- update pre-commit file and reformat 1 file